### PR TITLE
Removing rdagr2:gender from GND mapping

### DIFF
--- a/src/main/resources/vocabularies/gnd/gnd.xsl
+++ b/src/main/resources/vocabularies/gnd/gnd.xsl
@@ -169,18 +169,6 @@
                                 </xsl:for-each>
                             </skos:altLabel>
                         </xsl:for-each>
-                        <!-- Tag mapping: gndo:gender -> rdagr2:gender -->
-                        <xsl:for-each select="./gndo:gender">
-                            <rdagr2:gender>
-                                <!-- Text content mapping (only content with non-space characters) -->
-                                <xsl:for-each select="text()[normalize-space()]">
-                                    <xsl:if test="position() &gt; 1">
-                                        <xsl:text> </xsl:text>
-                                    </xsl:if>
-                                    <xsl:value-of select="normalize-space(.)"></xsl:value-of>
-                                </xsl:for-each>
-                            </rdagr2:gender>
-                        </xsl:for-each>
                         <!-- Tag mapping: gndo:dateOfDeath -> rdagr2:dateOfDeath -->
                         <xsl:for-each select="./gndo:dateOfDeath">
                             <rdagr2:dateOfDeath>


### PR DESCRIPTION
Removing mapping from gndo:gender to rdagr2:gender, following discussion in the Ops Team on 18 April 2023: https://docs.google.com/document/d/19urDPmeo6ey9wtBrRHFKjz58fGbq5ZEzfuKalLOzkSo/edit#heading=h.1p2c0ti2myob